### PR TITLE
ClientFakeEndpoints::with()

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -41,4 +41,4 @@ jobs:
         run: composer test
 
       - name: Run Pint
-        uses: aglipanci/laravel-pint-action@0.1.0
+        uses: composer pint-dry

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -44,4 +44,4 @@ jobs:
         run: composer test
 
       - name: Run Pint
-        uses: composer pint-dry
+        run: composer pint-dry

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches:
       - trunk
+  push:
+    branches:
+      - trunk
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is useful when you have one service that you want to fake, but not others.
 You can install the package via composer:
 
 ```bash
-composer require dbt/client-fake
+composer require dbt/client-fake --dev
 ```
 
 ## Usage

--- a/Source/ClientFakeEndpoints.php
+++ b/Source/ClientFakeEndpoints.php
@@ -23,6 +23,13 @@ class ClientFakeEndpoints
         return $this;
     }
 
+    public function with(Closure $closure): ClientFake
+    {
+        $closure($this);
+
+        return $this->clientFake;
+    }
+
     public function done(): ClientFake
     {
         return $this->clientFake;

--- a/Tests/ClientFakeEndpointsCollectionTest.php
+++ b/Tests/ClientFakeEndpointsCollectionTest.php
@@ -2,7 +2,7 @@
 
 namespace Dbt\ClientFake\Tests;
 use Dbt\ClientFake\ClientFakeEndpointsCollection;
-use Dbt\ClientFake\Tests\Fakes\BreedEndpoints;
+use Dbt\ClientFake\Tests\Fakes\BreedEps;
 use InvalidArgumentException;
 
 class ClientFakeEndpointsCollectionTest extends TestCase
@@ -11,7 +11,7 @@ class ClientFakeEndpointsCollectionTest extends TestCase
     public function constructing (): void
     {
         $collection = new ClientFakeEndpointsCollection([
-            'breeds' => BreedEndpoints::class,
+            'breeds' => BreedEps::class,
         ]);
 
         $this->assertInstanceOf(
@@ -31,7 +31,7 @@ class ClientFakeEndpointsCollectionTest extends TestCase
     public function has_a_key (): void
     {
         $collection = new ClientFakeEndpointsCollection([
-            'breeds' => BreedEndpoints::class,
+            'breeds' => BreedEps::class,
         ]);
 
         $this->assertTrue($collection->has('breeds'));
@@ -42,11 +42,11 @@ class ClientFakeEndpointsCollectionTest extends TestCase
     public function getting_a_member (): void
     {
         $collection = new ClientFakeEndpointsCollection([
-            'breeds' => BreedEndpoints::class,
+            'breeds' => BreedEps::class,
         ]);
 
         $this->assertInstanceOf(
-            BreedEndpoints::class,
+            BreedEps::class,
             $collection->get('breeds', $this->fake()),
         );
 

--- a/Tests/ClientFakeEndpointsCollectionTest.php
+++ b/Tests/ClientFakeEndpointsCollectionTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Dbt\ClientFake\Tests;
+
 use Dbt\ClientFake\ClientFakeEndpointsCollection;
 use Dbt\ClientFake\Tests\Fakes\BreedEps;
 use InvalidArgumentException;
@@ -8,7 +9,7 @@ use InvalidArgumentException;
 class ClientFakeEndpointsCollectionTest extends TestCase
 {
     /** @test */
-    public function constructing (): void
+    public function constructing(): void
     {
         $collection = new ClientFakeEndpointsCollection([
             'breeds' => BreedEps::class,
@@ -28,7 +29,7 @@ class ClientFakeEndpointsCollectionTest extends TestCase
     }
 
     /** @test */
-    public function has_a_key (): void
+    public function has_a_key(): void
     {
         $collection = new ClientFakeEndpointsCollection([
             'breeds' => BreedEps::class,
@@ -39,7 +40,7 @@ class ClientFakeEndpointsCollectionTest extends TestCase
     }
 
     /** @test */
-    public function getting_a_member (): void
+    public function getting_a_member(): void
     {
         $collection = new ClientFakeEndpointsCollection([
             'breeds' => BreedEps::class,

--- a/Tests/ClientFakeEndpointsTest.php
+++ b/Tests/ClientFakeEndpointsTest.php
@@ -2,7 +2,7 @@
 
 namespace Dbt\ClientFake\Tests;
 
-use Dbt\ClientFake\Tests\Fakes\BreedEndpoints;
+use Dbt\ClientFake\Tests\Fakes\BreedEps;
 use Throwable;
 
 class ClientFakeEndpointsTest extends TestCase
@@ -28,7 +28,7 @@ class ClientFakeEndpointsTest extends TestCase
     public function getting_the_endpoints_object (): void
     {
         $this->assertInstanceOf(
-            BreedEndpoints::class,
+            BreedEps::class,
             $this->fake()->breeds,
         );
     }
@@ -42,6 +42,28 @@ class ClientFakeEndpointsTest extends TestCase
         $this->fake()->breeds
                 ->index($breeds)
                 ->done()
+            ->getFact($fact)
+            ->commit();
+
+        $this->assertSame(
+            $breeds,
+            $this->service()->getBreeds()->json('data'),
+        );
+
+        $this->assertSame(
+            $fact,
+            $this->service()->getFact()->json('fact'),
+        );
+    }
+
+    /** @test */
+    public function using_a_closure (): void
+    {
+        $breeds = $this->breeds();
+        $fact = $this->fact();
+
+        $this->fake()
+            ->breeds->with(fn (BreedEps $eps) => $eps->index($breeds))
             ->getFact($fact)
             ->commit();
 

--- a/Tests/ClientFakeEndpointsTest.php
+++ b/Tests/ClientFakeEndpointsTest.php
@@ -1,4 +1,6 @@
-<?php /** @noinspection PhpUnhandledExceptionInspection */
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection */
 
 namespace Dbt\ClientFake\Tests;
 
@@ -8,7 +10,7 @@ use Throwable;
 class ClientFakeEndpointsTest extends TestCase
 {
     /** @test */
-    public function failing_to_get_the_endpoints_object (): void
+    public function failing_to_get_the_endpoints_object(): void
     {
         try {
             $this->fake()->somethingThatDoesntExist;
@@ -25,7 +27,7 @@ class ClientFakeEndpointsTest extends TestCase
     }
 
     /** @test */
-    public function getting_the_endpoints_object (): void
+    public function getting_the_endpoints_object(): void
     {
         $this->assertInstanceOf(
             BreedEps::class,
@@ -34,7 +36,7 @@ class ClientFakeEndpointsTest extends TestCase
     }
 
     /** @test */
-    public function using_the_endpoints (): void
+    public function using_the_endpoints(): void
     {
         $breeds = $this->breeds();
         $fact = $this->fact();
@@ -57,7 +59,7 @@ class ClientFakeEndpointsTest extends TestCase
     }
 
     /** @test */
-    public function using_a_closure (): void
+    public function using_a_closure(): void
     {
         $breeds = $this->breeds();
         $fact = $this->fact();

--- a/Tests/ClientFakeTest.php
+++ b/Tests/ClientFakeTest.php
@@ -5,11 +5,8 @@
 namespace Dbt\ClientFake\Tests;
 
 use Dbt\ClientFake\Tests\Fakes\CatFacts;
-use Dbt\ClientFake\Tests\Fakes\CatFactsFake;
 use Dbt\ClientFake\Tests\Fakes\FakeService;
-use Illuminate\Http\Client\Factory;
 use Illuminate\Http\Client\RequestException;
-use Illuminate\Support\Str;
 
 class ClientFakeTest extends TestCase
 {

--- a/Tests/Fakes/BreedEps.php
+++ b/Tests/Fakes/BreedEps.php
@@ -6,8 +6,9 @@ use Dbt\ClientFake\ClientFakeEndpoints;
 
 /**
  * @method \Dbt\ClientFake\Tests\Fakes\CatFactsFake done()
+ * @method \Dbt\ClientFake\Tests\Fakes\CatFactsFake with(\Closure $closure)
  */
-class BreedEndpoints extends ClientFakeEndpoints
+class BreedEps extends ClientFakeEndpoints
 {
     public function index(array $breeds): self
     {

--- a/Tests/Fakes/CatFactsFake.php
+++ b/Tests/Fakes/CatFactsFake.php
@@ -10,7 +10,7 @@ use Illuminate\Contracts\Foundation\Application;
  * The CatFacts Client Fake. This provides route faking capabilities for the
  * CatFacts Client.
  *
- * @property \Dbt\ClientFake\Tests\Fakes\BreedEndpoints $breeds
+ * @property \Dbt\ClientFake\Tests\Fakes\BreedEps $breeds
  */
 class CatFactsFake extends ClientFake
 {
@@ -25,7 +25,7 @@ class CatFactsFake extends ClientFake
         parent::__construct(
             app: $app,
             options: $options,
-            endpoints: ['breeds' => BreedEndpoints::class],
+            endpoints: ['breeds' => BreedEps::class],
         );
     }
 


### PR DESCRIPTION
Provides an alternative mechanism for setting up Endpoints classes. Instead of chaining and calling `done()`, you can pass a closure to the `with()` method that receives the Endpoints instance and can configure it from there. The `with()` method will return the parent `ClientFake` instance.